### PR TITLE
feat: Add comprehensive database seeders for Food Delivery API

### DIFF
--- a/app/Models/Chef.php
+++ b/app/Models/Chef.php
@@ -9,6 +9,9 @@ class Chef extends Model
 {
     use HasFactory;
 
+    protected $primaryKey = 'id';
+    public $incrementing = false;
+
     protected $fillable = [
         'id',
         'national_id',

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -9,6 +9,9 @@ class Customer extends Model
 {
     use HasFactory;
 
+    protected $primaryKey = 'id';
+    public $incrementing = false;
+
     protected $fillable = [
         'id',
         'preferred_payment_method',

--- a/database/migrations/2025_06_30_164114_create_addresses_table.php
+++ b/database/migrations/2025_06_30_164114_create_addresses_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('addresses', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('customer_id')->constrained('customers')->onDelete('cascade');
+            $table->unsignedBigInteger('customer_id');
             $table->integer('post_code');
             $table->text('address_text');
             $table->string('street');

--- a/database/migrations/2025_06_30_164131_create_dishes_table.php
+++ b/database/migrations/2025_06_30_164131_create_dishes_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('dishes', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('chef_id')->constrained('chefs')->onDelete('cascade');
+            $table->unsignedBigInteger('chef_id');
             $table->string('name');
             $table->text('description')->nullable();
             $table->string('image')->nullable();

--- a/database/migrations/2025_06_30_164232_create_coupons_table.php
+++ b/database/migrations/2025_06_30_164232_create_coupons_table.php
@@ -14,7 +14,7 @@ return new class extends Migration
         Schema::create('coupons', function (Blueprint $table) {
             $table->id();
             $table->string('code')->unique();
-            $table->foreignId('chef_id')->constrained('chefs')->onDelete('cascade');
+            $table->unsignedBigInteger('chef_id');
             $table->enum('discount_type', ['percentage', 'fixed']);
             $table->decimal('discount_value', 10, 2);
             $table->text('description')->nullable();

--- a/database/migrations/2025_06_30_164240_create_carts_table.php
+++ b/database/migrations/2025_06_30_164240_create_carts_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('carts', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('customer_id')->constrained('customers')->onDelete('cascade');
+            $table->unsignedBigInteger('customer_id');
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_06_30_164334_create_favorites_table.php
+++ b/database/migrations/2025_06_30_164334_create_favorites_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('favorites', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('customer_id')->constrained('customers')->onDelete('cascade');
+            $table->unsignedBigInteger('customer_id');
             $table->foreignId('dish_id')->constrained('dishes')->onDelete('cascade');
             $table->timestamp('created_at')->useCurrent();
         });

--- a/database/migrations/2025_06_30_164614_create_reviews_table.php
+++ b/database/migrations/2025_06_30_164614_create_reviews_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
     {
         Schema::create('reviews', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('customer_id')->constrained('customers')->onDelete('cascade');
-            $table->foreignId('chef_id')->constrained('chefs')->onDelete('cascade');
+            $table->unsignedBigInteger('customer_id');
+            $table->unsignedBigInteger('chef_id');
             $table->integer('rating');
             $table->text('comment')->nullable();
             $table->timestamp('created_at')->useCurrent();

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Category;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $categories = [
+            // Breakfast Categories
+            [
+                'name' => 'Traditional Breakfast',
+                'image' => 'https://images.unsplash.com/photo-1533089860892-a7c6f0a88666?w=400',
+                'meal_type' => 'breakfast',
+            ],
+            [
+                'name' => 'Healthy Breakfast',
+                'image' => 'https://images.unsplash.com/photo-1484723091739-30a097e8f929?w=400',
+                'meal_type' => 'breakfast',
+            ],
+            [
+                'name' => 'Continental Breakfast',
+                'image' => 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=400',
+                'meal_type' => 'breakfast',
+            ],
+            [
+                'name' => 'Pastries & Sweets',
+                'image' => 'https://images.unsplash.com/photo-1558961363-fa8fdf82db35?w=400',
+                'meal_type' => 'breakfast',
+            ],
+
+            // Lunch Categories
+            [
+                'name' => 'Egyptian Cuisine',
+                'image' => 'https://images.unsplash.com/photo-1544807976-9b2b24998552?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Italian Cuisine',
+                'image' => 'https://images.unsplash.com/photo-1565299624946-b28f40a0ca4b?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Lebanese & Middle Eastern',
+                'image' => 'https://images.unsplash.com/photo-1512852939750-1305098529bf?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Grilled & BBQ',
+                'image' => 'https://images.unsplash.com/photo-1555939594-58d7cb561ad1?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Seafood',
+                'image' => 'https://images.unsplash.com/photo-1559847844-5315695dadae?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Healthy & Diet',
+                'image' => 'https://images.unsplash.com/photo-1512621776951-a57141f2eefd?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Asian Cuisine',
+                'image' => 'https://images.unsplash.com/photo-1563379091339-03246963d7d3?w=400',
+                'meal_type' => 'lunch',
+            ],
+            [
+                'name' => 'Sandwiches & Wraps',
+                'image' => 'https://images.unsplash.com/photo-1565958011703-44f9829ba187?w=400',
+                'meal_type' => 'lunch',
+            ],
+
+            // Dinner Categories
+            [
+                'name' => 'Fine Dining',
+                'image' => 'https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=400',
+                'meal_type' => 'dinner',
+            ],
+            [
+                'name' => 'Traditional Egyptian',
+                'image' => 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?w=400',
+                'meal_type' => 'dinner',
+            ],
+            [
+                'name' => 'International Cuisine',
+                'image' => 'https://images.unsplash.com/photo-1567620905732-2d1ec7ab7445?w=400',
+                'meal_type' => 'dinner',
+            ],
+            [
+                'name' => 'Comfort Food',
+                'image' => 'https://images.unsplash.com/photo-1574484284002-952d92456975?w=400',
+                'meal_type' => 'dinner',
+            ],
+            [
+                'name' => 'Light Dinner',
+                'image' => 'https://images.unsplash.com/photo-1490645935967-10de6ba17061?w=400',
+                'meal_type' => 'dinner',
+            ],
+        ];
+
+        foreach ($categories as $categoryData) {
+            Category::create($categoryData);
+        }
+    }
+}

--- a/database/seeders/ChefSeeder.php
+++ b/database/seeders/ChefSeeder.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Chef;
+use App\Models\User;
+
+class ChefSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $chefUsers = User::where('type', 'chef')->get();
+
+        $chefData = [
+            [
+                'national_id' => '29501012345678',
+                'balance' => 2500.75,
+                'description' => 'Specializing in authentic Egyptian dishes with over 12 years of experience. Known for perfect koshari and traditional stews.',
+                'stripe_account_id' => 'acct_1234567890',
+                'location' => 'Maadi, Cairo, Egypt',
+                'is_verified' => true,
+            ],
+            [
+                'national_id' => '28612023456789',
+                'balance' => 3200.50,
+                'description' => 'Expert in Lebanese and Mediterranean cuisine. Famous for outstanding mezze platters and grilled specialties.',
+                'stripe_account_id' => 'acct_2345678901',
+                'location' => 'Zamalek, Cairo, Egypt',
+                'is_verified' => true,
+            ],
+            [
+                'national_id' => '29003034567890',
+                'balance' => 1850.25,
+                'description' => 'Italian cuisine master with certification from Culinary Institute of Italy. Pasta and risotto specialist.',
+                'stripe_account_id' => 'acct_3456789012',
+                'location' => 'New Cairo, Egypt',
+                'is_verified' => true,
+            ],
+            [
+                'national_id' => '29204045678901',
+                'balance' => 2100.00,
+                'description' => 'Award-winning pastry chef and dessert artist. Creates stunning fusion desserts blending East and West.',
+                'stripe_account_id' => 'acct_4567890123',
+                'location' => 'Heliopolis, Cairo, Egypt',
+                'is_verified' => true,
+            ],
+            [
+                'national_id' => '28805056789012',
+                'balance' => 2950.80,
+                'description' => 'BBQ and grilling specialist with expertise in Asian marinades and American smoking techniques.',
+                'stripe_account_id' => 'acct_5678901234',
+                'location' => 'Sheikh Zayed, Giza, Egypt',
+                'is_verified' => true,
+            ],
+            [
+                'national_id' => '29106067890123',
+                'balance' => 1750.40,
+                'description' => 'Health-conscious chef focusing on organic, locally-sourced ingredients. Keto and Mediterranean diet specialist.',
+                'stripe_account_id' => 'acct_6789012345',
+                'location' => 'Dokki, Giza, Egypt',
+                'is_verified' => false,
+            ],
+            [
+                'national_id' => '28507078901234',
+                'balance' => 3500.90,
+                'description' => 'Seafood expert with extensive knowledge of Red Sea and Mediterranean catches. Fresh fish daily.',
+                'stripe_account_id' => 'acct_7890123456',
+                'location' => 'Hurghada, Red Sea, Egypt',
+                'is_verified' => true,
+            ],
+            [
+                'national_id' => '29308089012345',
+                'balance' => 2200.60,
+                'description' => 'Traditional Egyptian home cooking with modern presentation. Comfort food that reminds you of grandma\'s kitchen.',
+                'stripe_account_id' => 'acct_8901234567',
+                'location' => 'Mohandessin, Giza, Egypt',
+                'is_verified' => false,
+            ],
+        ];
+
+        foreach ($chefUsers as $index => $user) {
+            if (isset($chefData[$index])) {
+                Chef::create([
+                    'id' => $user->id,
+                    'national_id' => $chefData[$index]['national_id'],
+                    'balance' => $chefData[$index]['balance'],
+                    'description' => $chefData[$index]['description'],
+                    'stripe_account_id' => $chefData[$index]['stripe_account_id'],
+                    'location' => $chefData[$index]['location'],
+                    'is_verified' => $chefData[$index]['is_verified'],
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/CouponSeeder.php
+++ b/database/seeders/CouponSeeder.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Coupon;
+use App\Models\Chef;
+use Carbon\Carbon;
+
+class CouponSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $chefs = Chef::all();
+
+        $coupons = [
+            // Welcome discount coupons
+            [
+                'code' => 'WELCOME20',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 20.00,
+                'description' => 'Welcome offer! Get 20% off on your first order from this chef.',
+                'expires_at' => Carbon::now()->addMonths(3),
+            ],
+            [
+                'code' => 'NEWCUSTOMER15',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 15.00,
+                'description' => 'New customer special - 15% discount on all menu items.',
+                'expires_at' => Carbon::now()->addMonths(2),
+            ],
+
+            // Fixed amount discount coupons
+            [
+                'code' => 'SAVE50',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 50.00,
+                'description' => 'Save 50 EGP on orders above 200 EGP.',
+                'expires_at' => Carbon::now()->addWeeks(6),
+            ],
+            [
+                'code' => 'FLAT30',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 30.00,
+                'description' => 'Flat 30 EGP discount on any order.',
+                'expires_at' => Carbon::now()->addMonth(),
+            ],
+
+            // Weekend specials
+            [
+                'code' => 'WEEKEND25',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 25.00,
+                'description' => 'Weekend special! 25% off on Friday and Saturday orders.',
+                'expires_at' => Carbon::now()->addWeeks(8),
+            ],
+            [
+                'code' => 'FRIDAY100',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 100.00,
+                'description' => 'Friday mega deal - 100 EGP off on orders above 500 EGP.',
+                'expires_at' => Carbon::now()->addWeeks(4),
+            ],
+
+            // Loyalty coupons
+            [
+                'code' => 'LOYAL10',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 10.00,
+                'description' => 'Loyalty reward for returning customers - 10% off.',
+                'expires_at' => Carbon::now()->addMonths(6),
+            ],
+            [
+                'code' => 'VIP30',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 30.00,
+                'description' => 'VIP customer exclusive - 30% discount on premium dishes.',
+                'expires_at' => Carbon::now()->addMonths(4),
+            ],
+
+            // Special occasion coupons
+            [
+                'code' => 'RAMADAN20',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 20.00,
+                'description' => 'Ramadan special offer - 20% off on traditional dishes.',
+                'expires_at' => Carbon::now()->addMonths(2),
+            ],
+            [
+                'code' => 'EID150',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 150.00,
+                'description' => 'Eid celebration discount - 150 EGP off on family meals.',
+                'expires_at' => Carbon::now()->addWeeks(3),
+            ],
+
+            // Limited time offers
+            [
+                'code' => 'FLASH35',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 35.00,
+                'description' => 'Flash sale! 35% off for the next 48 hours only.',
+                'expires_at' => Carbon::now()->addDays(2),
+            ],
+            [
+                'code' => 'MIDNIGHT40',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 40.00,
+                'description' => 'Midnight madness - 40% off on late night orders.',
+                'expires_at' => Carbon::now()->addWeeks(2),
+            ],
+
+            // Cuisine-specific coupons
+            [
+                'code' => 'ITALIAN25',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 25.00,
+                'description' => 'Italian cuisine lover discount - 25% off on pasta and pizza.',
+                'expires_at' => Carbon::now()->addMonths(3),
+            ],
+            [
+                'code' => 'SEAFOOD75',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 75.00,
+                'description' => 'Fresh seafood special - 75 EGP off on seafood dishes.',
+                'expires_at' => Carbon::now()->addWeeks(5),
+            ],
+
+            // Healthy options coupons
+            [
+                'code' => 'HEALTHY15',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 15.00,
+                'description' => 'Healthy choice discount - 15% off on diet-friendly meals.',
+                'expires_at' => Carbon::now()->addMonths(4),
+            ],
+            [
+                'code' => 'KETO50',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 50.00,
+                'description' => 'Keto diet special - 50 EGP off on keto-friendly dishes.',
+                'expires_at' => Carbon::now()->addWeeks(6),
+            ],
+
+            // Bulk order discounts
+            [
+                'code' => 'BULK200',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 200.00,
+                'description' => 'Bulk order discount - 200 EGP off on orders above 1000 EGP.',
+                'expires_at' => Carbon::now()->addMonths(5),
+            ],
+            [
+                'code' => 'PARTY30',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 30.00,
+                'description' => 'Party catering special - 30% off on large orders.',
+                'expires_at' => Carbon::now()->addWeeks(8),
+            ],
+
+            // Student discounts
+            [
+                'code' => 'STUDENT12',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 12.00,
+                'description' => 'Student discount - 12% off with valid student ID.',
+                'expires_at' => Carbon::now()->addMonths(12),
+            ],
+
+            // Early bird specials
+            [
+                'code' => 'EARLYBIRD20',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'percentage',
+                'discount_value' => 20.00,
+                'description' => 'Early bird special - 20% off on orders placed before 11 AM.',
+                'expires_at' => Carbon::now()->addMonths(2),
+            ],
+
+            // Expired coupons for testing
+            [
+                'code' => 'EXPIRED50',
+                'chef_id' => $chefs->random()->id,
+                'discount_type' => 'fixed',
+                'discount_value' => 50.00,
+                'description' => 'This coupon has expired and should not be usable.',
+                'expires_at' => Carbon::now()->subWeeks(2),
+            ],
+        ];
+
+        foreach ($coupons as $couponData) {
+            Coupon::create($couponData);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,6 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +11,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+        // Run seeders in the correct order to maintain foreign key relationships
+        $this->call([
+            UserSeeder::class,          // Create users first (for chefs)
+            CategorySeeder::class,      // Create categories
+            IngredientSeeder::class,    // Create ingredients
+            ChefSeeder::class,          // Create chef profiles (depends on users)
+            DishSeeder::class,          // Create dishes (depends on chefs and categories)
+            DishSizeSeeder::class,      // Create dish sizes (depends on dishes)
+            DishIngredientSeeder::class, // Link dishes with ingredients (depends on dishes and ingredients)
+            CouponSeeder::class,        // Create coupons (depends on chefs)
         ]);
     }
 }

--- a/database/seeders/DishIngredientSeeder.php
+++ b/database/seeders/DishIngredientSeeder.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\DishIngredient;
+use App\Models\Dish;
+use App\Models\Ingredient;
+
+class DishIngredientSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $dishes = Dish::all();
+        $ingredients = Ingredient::all();
+
+        foreach ($dishes as $dish) {
+            $dishIngredients = $this->getIngredientsForDish($dish, $ingredients);
+            
+            foreach ($dishIngredients as $ingredientId) {
+                DishIngredient::create([
+                    'dish_id' => $dish->id,
+                    'ingredient_id' => $ingredientId,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Get appropriate ingredients for each dish
+     */
+    private function getIngredientsForDish($dish, $ingredients)
+    {
+        $dishName = strtolower($dish->name);
+        $selectedIngredients = [];
+
+        // Koshari ingredients
+        if (stripos($dishName, 'koshari') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Rice', 'Lentils', 'Pasta', 'Onion', 'Tomatoes', 'Garlic', 'Cumin', 'Vegetable Oil'
+            ]);
+        }
+        // Italian dishes
+        elseif (stripos($dishName, 'carbonara') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Pasta', 'Eggs', 'Cheese', 'Black Pepper', 'Garlic', 'Olive Oil'
+            ]);
+        }
+        elseif (stripos($dishName, 'pizza') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Flour', 'Tomatoes', 'Cheese', 'Basil', 'Olive Oil'
+            ]);
+        }
+        // Grilled dishes
+        elseif (stripos($dishName, 'grill') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Beef', 'Lamb', 'Chicken', 'Onion', 'Bell Peppers', 'Rice', 'Cumin', 'Paprika'
+            ]);
+        }
+        // Seafood dishes
+        elseif (stripos($dishName, 'fish') !== false || stripos($dishName, 'seafood') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Fish', 'Shrimp', 'Lemon Juice', 'Olive Oil', 'Garlic', 'Thyme', 'Salt'
+            ]);
+        }
+        // Chicken dishes
+        elseif (stripos($dishName, 'chicken') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Chicken', 'Rice', 'Onion', 'Garlic', 'Olive Oil', 'Salt', 'Black Pepper'
+            ]);
+        }
+        // Breakfast dishes
+        elseif (stripos($dishName, 'eggs') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Eggs', 'Butter', 'Bread', 'Milk'
+            ]);
+        }
+        // Salad dishes
+        elseif (stripos($dishName, 'salad') !== false) {
+            $selectedIngredients = $this->getIngredientsByName($ingredients, [
+                'Lettuce', 'Tomatoes', 'Cucumber', 'Olive Oil', 'Lemon Juice'
+            ]);
+        }
+        // Default ingredients for other dishes
+        else {
+            $randomIngredients = $ingredients->random(rand(3, 6));
+            $selectedIngredients = $randomIngredients->pluck('id')->toArray();
+        }
+
+        return $selectedIngredients;
+    }
+
+    /**
+     * Get ingredient IDs by their names
+     */
+    private function getIngredientsByName($ingredients, $names)
+    {
+        $ids = [];
+        foreach ($names as $name) {
+            $ingredient = $ingredients->where('name', $name)->first();
+            if ($ingredient) {
+                $ids[] = $ingredient->id;
+            }
+        }
+        return $ids;
+    }
+}

--- a/database/seeders/DishSeeder.php
+++ b/database/seeders/DishSeeder.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Dish;
+use App\Models\Chef;
+use App\Models\Category;
+
+class DishSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $chefs = Chef::all();
+        $categories = Category::all();
+
+        $dishes = [
+            // Traditional Egyptian Dishes
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Koshari',
+                'description' => 'Egypt\'s national dish with rice, lentils, pasta, crispy onions, and spicy tomato sauce',
+                'image' => 'https://images.unsplash.com/photo-1544807976-9b2b24998552?w=500',
+                'is_available' => true,
+                'total_rate' => 127,
+                'avg_rate' => 4.8,
+                'category_id' => $categories->where('name', 'Egyptian Cuisine')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Molokhia with Chicken',
+                'description' => 'Traditional Egyptian green soup made with jute leaves, served with tender chicken',
+                'image' => 'https://images.unsplash.com/photo-1567620905732-2d1ec7ab7445?w=500',
+                'is_available' => true,
+                'total_rate' => 89,
+                'avg_rate' => 4.5,
+                'category_id' => $categories->where('name', 'Egyptian Cuisine')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Ful Medames',
+                'description' => 'Traditional Egyptian breakfast of slow-cooked fava beans with tahini, olive oil, and vegetables',
+                'image' => 'https://images.unsplash.com/photo-1533089860892-a7c6f0a88666?w=500',
+                'is_available' => true,
+                'total_rate' => 156,
+                'avg_rate' => 4.6,
+                'category_id' => $categories->where('name', 'Traditional Breakfast')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Mahshi (Stuffed Vegetables)',
+                'description' => 'Cabbage, zucchini, and bell peppers stuffed with rice, herbs, and minced meat',
+                'image' => 'https://images.unsplash.com/photo-1574484284002-952d92456975?w=500',
+                'is_available' => true,
+                'total_rate' => 73,
+                'avg_rate' => 4.3,
+                'category_id' => $categories->where('name', 'Traditional Egyptian')->first()->id ?? null,
+            ],
+
+            // Italian Dishes
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Spaghetti Carbonara',
+                'description' => 'Classic Italian pasta with eggs, pancetta, pecorino cheese, and black pepper',
+                'image' => 'https://images.unsplash.com/photo-1565299624946-b28f40a0ca4b?w=500',
+                'is_available' => true,
+                'total_rate' => 201,
+                'avg_rate' => 4.9,
+                'category_id' => $categories->where('name', 'Italian Cuisine')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Risotto ai Frutti di Mare',
+                'description' => 'Creamy Italian rice dish with mixed seafood, saffron, and white wine',
+                'image' => 'https://images.unsplash.com/photo-1559847844-5315695dadae?w=500',
+                'is_available' => true,
+                'total_rate' => 94,
+                'avg_rate' => 4.7,
+                'category_id' => $categories->where('name', 'Seafood')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Margherita Pizza',
+                'description' => 'Traditional Neapolitan pizza with tomato sauce, mozzarella, basil, and olive oil',
+                'image' => 'https://images.unsplash.com/photo-1574071318508-1cdbab80d002?w=500',
+                'is_available' => true,
+                'total_rate' => 312,
+                'avg_rate' => 4.8,
+                'category_id' => $categories->where('name', 'Italian Cuisine')->first()->id ?? null,
+            ],
+
+            // Lebanese & Middle Eastern
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Mixed Grill Platter',
+                'description' => 'Assorted grilled meats including kebab, kofta, and lamb chops with rice and grilled vegetables',
+                'image' => 'https://images.unsplash.com/photo-1555939594-58d7cb561ad1?w=500',
+                'is_available' => true,
+                'total_rate' => 178,
+                'avg_rate' => 4.6,
+                'category_id' => $categories->where('name', 'Grilled & BBQ')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Hummus with Lamb',
+                'description' => 'Creamy chickpea dip topped with spiced ground lamb, pine nuts, and olive oil',
+                'image' => 'https://images.unsplash.com/photo-1512852939750-1305098529bf?w=500',
+                'is_available' => true,
+                'total_rate' => 145,
+                'avg_rate' => 4.4,
+                'category_id' => $categories->where('name', 'Lebanese & Middle Eastern')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Tabbouleh Salad',
+                'description' => 'Fresh parsley salad with tomatoes, onions, mint, bulgur, lemon juice, and olive oil',
+                'image' => 'https://images.unsplash.com/photo-1512621776951-a57141f2eefd?w=500',
+                'is_available' => true,
+                'total_rate' => 87,
+                'avg_rate' => 4.2,
+                'category_id' => $categories->where('name', 'Healthy & Diet')->first()->id ?? null,
+            ],
+
+            // Seafood Dishes
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Grilled Red Sea Fish',
+                'description' => 'Fresh catch of the day grilled with Mediterranean herbs, lemon, and olive oil',
+                'image' => 'https://images.unsplash.com/photo-1559847844-5315695dadae?w=500',
+                'is_available' => true,
+                'total_rate' => 132,
+                'avg_rate' => 4.7,
+                'category_id' => $categories->where('name', 'Seafood')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Seafood Paella',
+                'description' => 'Spanish rice dish with shrimp, mussels, calamari, and saffron',
+                'image' => 'https://images.unsplash.com/photo-1559847844-5315695dadae?w=500',
+                'is_available' => true,
+                'total_rate' => 98,
+                'avg_rate' => 4.5,
+                'category_id' => $categories->where('name', 'Seafood')->first()->id ?? null,
+            ],
+
+            // Healthy & Diet Options
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Quinoa Buddha Bowl',
+                'description' => 'Nutritious bowl with quinoa, roasted vegetables, avocado, and tahini dressing',
+                'image' => 'https://images.unsplash.com/photo-1512621776951-a57141f2eefd?w=500',
+                'is_available' => true,
+                'total_rate' => 76,
+                'avg_rate' => 4.3,
+                'category_id' => $categories->where('name', 'Healthy & Diet')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Keto Salmon with Asparagus',
+                'description' => 'Grilled salmon fillet with roasted asparagus and herb butter',
+                'image' => 'https://images.unsplash.com/photo-1485921325833-c519f76c4927?w=500',
+                'is_available' => true,
+                'total_rate' => 65,
+                'avg_rate' => 4.6,
+                'category_id' => $categories->where('name', 'Healthy & Diet')->first()->id ?? null,
+            ],
+
+            // Asian Cuisine
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Chicken Teriyaki with Rice',
+                'description' => 'Grilled chicken glazed with homemade teriyaki sauce, served with steamed rice and vegetables',
+                'image' => 'https://images.unsplash.com/photo-1563379091339-03246963d7d3?w=500',
+                'is_available' => true,
+                'total_rate' => 143,
+                'avg_rate' => 4.4,
+                'category_id' => $categories->where('name', 'Asian Cuisine')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Thai Green Curry',
+                'description' => 'Spicy coconut curry with chicken, Thai eggplant, basil, and jasmine rice',
+                'image' => 'https://images.unsplash.com/photo-1455619452474-d2be8b1e70cd?w=500',
+                'is_available' => true,
+                'total_rate' => 89,
+                'avg_rate' => 4.5,
+                'category_id' => $categories->where('name', 'Asian Cuisine')->first()->id ?? null,
+            ],
+
+            // Breakfast Items
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Eggs Benedict',
+                'description' => 'Poached eggs on English muffins with Canadian bacon and hollandaise sauce',
+                'image' => 'https://images.unsplash.com/photo-1513475382585-d06e58bcb0e0?w=500',
+                'is_available' => true,
+                'total_rate' => 234,
+                'avg_rate' => 4.7,
+                'category_id' => $categories->where('name', 'Continental Breakfast')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Acai Bowl',
+                'description' => 'Superfood bowl with acai, granola, fresh berries, and coconut flakes',
+                'image' => 'https://images.unsplash.com/photo-1484723091739-30a097e8f929?w=500',
+                'is_available' => true,
+                'total_rate' => 167,
+                'avg_rate' => 4.5,
+                'category_id' => $categories->where('name', 'Healthy Breakfast')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Croissant with Zaatar',
+                'description' => 'Buttery French croissant filled with traditional Middle Eastern zaatar mix',
+                'image' => 'https://images.unsplash.com/photo-1558961363-fa8fdf82db35?w=500',
+                'is_available' => true,
+                'total_rate' => 98,
+                'avg_rate' => 4.2,
+                'category_id' => $categories->where('name', 'Pastries & Sweets')->first()->id ?? null,
+            ],
+
+            // Sandwiches & Wraps
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Chicken Shawarma Wrap',
+                'description' => 'Marinated chicken with vegetables, tahini sauce, and pickles in a warm tortilla',
+                'image' => 'https://images.unsplash.com/photo-1565958011703-44f9829ba187?w=500',
+                'is_available' => true,
+                'total_rate' => 298,
+                'avg_rate' => 4.6,
+                'category_id' => $categories->where('name', 'Sandwiches & Wraps')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Falafel Sandwich',
+                'description' => 'Crispy chickpea fritters with fresh vegetables and tahini in pita bread',
+                'image' => 'https://images.unsplash.com/photo-1529059997568-3d847b1154f0?w=500',
+                'is_available' => true,
+                'total_rate' => 187,
+                'avg_rate' => 4.3,
+                'category_id' => $categories->where('name', 'Sandwiches & Wraps')->first()->id ?? null,
+            ],
+
+            // Fine Dining
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Duck Confit with Orange Sauce',
+                'description' => 'Slow-cooked duck leg with crispy skin, served with orange reduction and roasted vegetables',
+                'image' => 'https://images.unsplash.com/photo-1414235077428-338989a2e8c0?w=500',
+                'is_available' => true,
+                'total_rate' => 54,
+                'avg_rate' => 4.9,
+                'category_id' => $categories->where('name', 'Fine Dining')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Beef Tenderloin with Truffle',
+                'description' => 'Premium beef tenderloin with truffle sauce, fondant potatoes, and seasonal vegetables',
+                'image' => 'https://images.unsplash.com/photo-1546833999-b9f581a1996d?w=500',
+                'is_available' => true,
+                'total_rate' => 43,
+                'avg_rate' => 4.8,
+                'category_id' => $categories->where('name', 'Fine Dining')->first()->id ?? null,
+            ],
+
+            // Desserts
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Baklava Cheesecake',
+                'description' => 'Fusion dessert combining New York cheesecake with traditional baklava flavors',
+                'image' => 'https://images.unsplash.com/photo-1551024739-2bd62a9a3480?w=500',
+                'is_available' => true,
+                'total_rate' => 112,
+                'avg_rate' => 4.7,
+                'category_id' => $categories->where('name', 'Pastries & Sweets')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Chocolate Fondant',
+                'description' => 'Warm chocolate cake with molten center, served with vanilla ice cream',
+                'image' => 'https://images.unsplash.com/photo-1551024739-2bd62a9a3480?w=500',
+                'is_available' => true,
+                'total_rate' => 189,
+                'avg_rate' => 4.8,
+                'category_id' => $categories->where('name', 'Pastries & Sweets')->first()->id ?? null,
+            ],
+
+            // More varied dishes
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Beef Burger Deluxe',
+                'description' => 'Juicy beef patty with cheddar cheese, lettuce, tomato, and special sauce on brioche bun',
+                'image' => 'https://images.unsplash.com/photo-1568901346375-23c9450c58cd?w=500',
+                'is_available' => true,
+                'total_rate' => 267,
+                'avg_rate' => 4.4,
+                'category_id' => $categories->where('name', 'Comfort Food')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Vegetarian Lasagna',
+                'description' => 'Layers of pasta with ricotta, spinach, mushrooms, and marinara sauce',
+                'image' => 'https://images.unsplash.com/photo-1574894709920-11b28e7367e3?w=500',
+                'is_available' => true,
+                'total_rate' => 98,
+                'avg_rate' => 4.3,
+                'category_id' => $categories->where('name', 'Italian Cuisine')->first()->id ?? null,
+            ],
+            [
+                'chef_id' => $chefs->random()->id,
+                'name' => 'Chicken Caesar Salad',
+                'description' => 'Crisp romaine lettuce with grilled chicken, parmesan cheese, croutons, and Caesar dressing',
+                'image' => 'https://images.unsplash.com/photo-1512852939750-1305098529bf?w=500',
+                'is_available' => true,
+                'total_rate' => 156,
+                'avg_rate' => 4.1,
+                'category_id' => $categories->where('name', 'Light Dinner')->first()->id ?? null,
+            ],
+        ];
+
+        foreach ($dishes as $dishData) {
+            Dish::create($dishData);
+        }
+    }
+}

--- a/database/seeders/DishSizeSeeder.php
+++ b/database/seeders/DishSizeSeeder.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\DishSize;
+use App\Models\Dish;
+
+class DishSizeSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $dishes = Dish::all();
+
+        foreach ($dishes as $dish) {
+            // Determine base price based on category and dish type
+            $basePrice = $this->getBasePriceForDish($dish);
+
+            // Add sizes for each dish with price variations
+            $sizes = [
+                [
+                    'dish_id' => $dish->id,
+                    'size' => 'small',
+                    'price' => round($basePrice * 0.75, 2), // 75% of base price
+                ],
+                [
+                    'dish_id' => $dish->id,
+                    'size' => 'medium',
+                    'price' => $basePrice, // Base price
+                ],
+                [
+                    'dish_id' => $dish->id,
+                    'size' => 'large',
+                    'price' => round($basePrice * 1.4, 2), // 140% of base price
+                ]
+            ];
+
+            foreach ($sizes as $sizeData) {
+                DishSize::create($sizeData);
+            }
+        }
+    }
+
+    /**
+     * Determine base price based on dish characteristics
+     */
+    private function getBasePriceForDish($dish)
+    {
+        $dishName = strtolower($dish->name);
+        
+        // Fine dining dishes - higher prices
+        if (stripos($dishName, 'truffle') !== false || 
+            stripos($dishName, 'duck confit') !== false || 
+            stripos($dishName, 'beef tenderloin') !== false) {
+            return rand(450, 650); // 450-650 EGP
+        }
+        
+        // Seafood dishes - premium pricing
+        if (stripos($dishName, 'seafood') !== false || 
+            stripos($dishName, 'salmon') !== false || 
+            stripos($dishName, 'fish') !== false ||
+            stripos($dishName, 'paella') !== false) {
+            return rand(250, 400); // 250-400 EGP
+        }
+        
+        // Italian pasta and pizza - moderate pricing
+        if (stripos($dishName, 'pasta') !== false || 
+            stripos($dishName, 'pizza') !== false || 
+            stripos($dishName, 'risotto') !== false ||
+            stripos($dishName, 'carbonara') !== false ||
+            stripos($dishName, 'lasagna') !== false) {
+            return rand(150, 280); // 150-280 EGP
+        }
+        
+        // Grilled meat dishes - moderate to high pricing
+        if (stripos($dishName, 'grill') !== false || 
+            stripos($dishName, 'beef') !== false || 
+            stripos($dishName, 'lamb') !== false ||
+            stripos($dishName, 'burger') !== false) {
+            return rand(180, 320); // 180-320 EGP
+        }
+        
+        // Breakfast items - lower pricing
+        if (stripos($dishName, 'eggs') !== false || 
+            stripos($dishName, 'croissant') !== false || 
+            stripos($dishName, 'ful') !== false ||
+            stripos($dishName, 'acai') !== false) {
+            return rand(45, 120); // 45-120 EGP
+        }
+        
+        // Sandwiches and wraps - moderate pricing
+        if (stripos($dishName, 'sandwich') !== false || 
+            stripos($dishName, 'wrap') !== false || 
+            stripos($dishName, 'shawarma') !== false ||
+            stripos($dishName, 'falafel') !== false) {
+            return rand(80, 150); // 80-150 EGP
+        }
+        
+        // Salads and healthy options - moderate pricing
+        if (stripos($dishName, 'salad') !== false || 
+            stripos($dishName, 'quinoa') !== false || 
+            stripos($dishName, 'tabbouleh') !== false ||
+            stripos($dishName, 'healthy') !== false) {
+            return rand(90, 180); // 90-180 EGP
+        }
+        
+        // Desserts - moderate pricing
+        if (stripos($dishName, 'cheesecake') !== false || 
+            stripos($dishName, 'fondant') !== false || 
+            stripos($dishName, 'baklava') !== false) {
+            return rand(70, 140); // 70-140 EGP
+        }
+        
+        // Asian cuisine - moderate pricing
+        if (stripos($dishName, 'teriyaki') !== false || 
+            stripos($dishName, 'curry') !== false || 
+            stripos($dishName, 'thai') !== false) {
+            return rand(120, 220); // 120-220 EGP
+        }
+        
+        // Traditional Egyptian dishes - affordable pricing
+        if (stripos($dishName, 'koshari') !== false || 
+            stripos($dishName, 'molokhia') !== false || 
+            stripos($dishName, 'mahshi') !== false) {
+            return rand(60, 140); // 60-140 EGP
+        }
+        
+        // Default pricing for other dishes
+        return rand(100, 200); // 100-200 EGP
+    }
+}

--- a/database/seeders/IngredientSeeder.php
+++ b/database/seeders/IngredientSeeder.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\Ingredient;
+
+class IngredientSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $ingredients = [
+            // Basic Ingredients
+            ['name' => 'Rice', 'type' => 'basic'],
+            ['name' => 'Chicken', 'type' => 'basic'],
+            ['name' => 'Beef', 'type' => 'basic'],
+            ['name' => 'Lamb', 'type' => 'basic'],
+            ['name' => 'Fish', 'type' => 'basic'],
+            ['name' => 'Shrimp', 'type' => 'basic'],
+            ['name' => 'Eggs', 'type' => 'basic'],
+            ['name' => 'Milk', 'type' => 'basic'],
+            ['name' => 'Cheese', 'type' => 'basic'],
+            ['name' => 'Yogurt', 'type' => 'basic'],
+            ['name' => 'Butter', 'type' => 'basic'],
+            ['name' => 'Olive Oil', 'type' => 'basic'],
+            ['name' => 'Vegetable Oil', 'type' => 'basic'],
+            ['name' => 'Flour', 'type' => 'basic'],
+            ['name' => 'Sugar', 'type' => 'basic'],
+            ['name' => 'Salt', 'type' => 'basic'],
+            ['name' => 'Black Pepper', 'type' => 'basic'],
+            ['name' => 'Garlic', 'type' => 'basic'],
+            ['name' => 'Onion', 'type' => 'basic'],
+            ['name' => 'Ginger', 'type' => 'basic'],
+            ['name' => 'Cumin', 'type' => 'basic'],
+            ['name' => 'Coriander', 'type' => 'basic'],
+            ['name' => 'Paprika', 'type' => 'basic'],
+            ['name' => 'Cinnamon', 'type' => 'basic'],
+            ['name' => 'Turmeric', 'type' => 'basic'],
+            ['name' => 'Bay Leaves', 'type' => 'basic'],
+            ['name' => 'Thyme', 'type' => 'basic'],
+            ['name' => 'Basil', 'type' => 'basic'],
+            ['name' => 'Parsley', 'type' => 'basic'],
+            ['name' => 'Cilantro', 'type' => 'basic'],
+            ['name' => 'Mint', 'type' => 'basic'],
+            ['name' => 'Dill', 'type' => 'basic'],
+            ['name' => 'Tomatoes', 'type' => 'basic'],
+            ['name' => 'Potatoes', 'type' => 'basic'],
+            ['name' => 'Carrots', 'type' => 'basic'],
+            ['name' => 'Bell Peppers', 'type' => 'basic'],
+            ['name' => 'Cucumber', 'type' => 'basic'],
+            ['name' => 'Lettuce', 'type' => 'basic'],
+            ['name' => 'Spinach', 'type' => 'basic'],
+            ['name' => 'Cabbage', 'type' => 'basic'],
+            ['name' => 'Eggplant', 'type' => 'basic'],
+            ['name' => 'Zucchini', 'type' => 'basic'],
+            ['name' => 'Green Beans', 'type' => 'basic'],
+            ['name' => 'Peas', 'type' => 'basic'],
+            ['name' => 'Corn', 'type' => 'basic'],
+            ['name' => 'Mushrooms', 'type' => 'basic'],
+            ['name' => 'Pasta', 'type' => 'basic'],
+            ['name' => 'Bread', 'type' => 'basic'],
+            ['name' => 'Tahini', 'type' => 'basic'],
+            ['name' => 'Hummus', 'type' => 'basic'],
+            ['name' => 'Fava Beans', 'type' => 'basic'],
+            ['name' => 'Lentils', 'type' => 'basic'],
+            ['name' => 'Chickpeas', 'type' => 'basic'],
+            ['name' => 'Kidney Beans', 'type' => 'basic'],
+            ['name' => 'Nuts', 'type' => 'basic'],
+            ['name' => 'Almonds', 'type' => 'basic'],
+            ['name' => 'Walnuts', 'type' => 'basic'],
+            ['name' => 'Pine Nuts', 'type' => 'basic'],
+            ['name' => 'Honey', 'type' => 'basic'],
+            ['name' => 'Vinegar', 'type' => 'basic'],
+            ['name' => 'Lemon Juice', 'type' => 'basic'],
+            ['name' => 'Tomato Paste', 'type' => 'basic'],
+            ['name' => 'Coconut Milk', 'type' => 'basic'],
+            ['name' => 'Soy Sauce', 'type' => 'basic'],
+            ['name' => 'Sesame Oil', 'type' => 'basic'],
+            ['name' => 'Vanilla', 'type' => 'basic'],
+            ['name' => 'Chocolate', 'type' => 'basic'],
+
+            // Fruits
+            ['name' => 'Apples', 'type' => 'fruit'],
+            ['name' => 'Bananas', 'type' => 'fruit'],
+            ['name' => 'Oranges', 'type' => 'fruit'],
+            ['name' => 'Lemons', 'type' => 'fruit'],
+            ['name' => 'Limes', 'type' => 'fruit'],
+            ['name' => 'Grapes', 'type' => 'fruit'],
+            ['name' => 'Strawberries', 'type' => 'fruit'],
+            ['name' => 'Blueberries', 'type' => 'fruit'],
+            ['name' => 'Raspberries', 'type' => 'fruit'],
+            ['name' => 'Blackberries', 'type' => 'fruit'],
+            ['name' => 'Mangoes', 'type' => 'fruit'],
+            ['name' => 'Pineapple', 'type' => 'fruit'],
+            ['name' => 'Kiwi', 'type' => 'fruit'],
+            ['name' => 'Papaya', 'type' => 'fruit'],
+            ['name' => 'Watermelon', 'type' => 'fruit'],
+            ['name' => 'Cantaloupe', 'type' => 'fruit'],
+            ['name' => 'Peaches', 'type' => 'fruit'],
+            ['name' => 'Pears', 'type' => 'fruit'],
+            ['name' => 'Plums', 'type' => 'fruit'],
+            ['name' => 'Cherries', 'type' => 'fruit'],
+            ['name' => 'Apricots', 'type' => 'fruit'],
+            ['name' => 'Figs', 'type' => 'fruit'],
+            ['name' => 'Dates', 'type' => 'fruit'],
+            ['name' => 'Pomegranate', 'type' => 'fruit'],
+            ['name' => 'Avocado', 'type' => 'fruit'],
+            ['name' => 'Coconut', 'type' => 'fruit'],
+        ];
+
+        foreach ($ingredients as $ingredientData) {
+            Ingredient::create($ingredientData);
+        }
+    }
+}

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $chefUsers = [
+            [
+                'name' => 'Ahmed Hassan',
+                'email' => 'ahmed.hassan@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201012345678',
+                'profile_image' => 'https://images.unsplash.com/photo-1583394293214-28a1386e5ebb?w=300',
+                'bio' => 'Experienced Egyptian chef specializing in traditional Middle Eastern cuisine with modern twists.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Fatima Al-Zahra',
+                'email' => 'fatima.alzahra@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201123456789',
+                'profile_image' => 'https://images.unsplash.com/photo-1566554273541-37a9ca77b91b?w=300',
+                'bio' => 'Master chef with 15 years of experience in Mediterranean and Lebanese cuisine.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Omar Khaled',
+                'email' => 'omar.khaled@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201234567890',
+                'profile_image' => 'https://images.unsplash.com/photo-1559339352-11d035aa65de?w=300',
+                'bio' => 'Italian cuisine expert and pasta specialist with international training.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Yasmin Mohamed',
+                'email' => 'yasmin.mohamed@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201345678901',
+                'profile_image' => 'https://images.unsplash.com/photo-1607631568010-a87245c0daf8?w=300',
+                'bio' => 'Dessert and bakery specialist, known for fusion desserts combining Eastern and Western flavors.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Karim Abdullah',
+                'email' => 'karim.abdullah@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201456789012',
+                'profile_image' => 'https://images.unsplash.com/photo-1577219491135-ce391730fb2c?w=300',
+                'bio' => 'BBQ and grilling expert, specializing in Asian and American barbecue styles.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Mona Saeed',
+                'email' => 'mona.saeed@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201567890123',
+                'profile_image' => 'https://images.unsplash.com/photo-1594736797933-d0401ba552fe?w=300',
+                'bio' => 'Healthy cuisine chef focusing on organic ingredients and diet-friendly meals.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Hassan Ali',
+                'email' => 'hassan.ali@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201678901234',
+                'profile_image' => 'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=300',
+                'bio' => 'Seafood specialist with expertise in Mediterranean and Red Sea cuisine.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+            [
+                'name' => 'Nadia Ibrahim',
+                'email' => 'nadia.ibrahim@chef.com',
+                'password' => Hash::make('password123'),
+                'phone' => '+201789012345',
+                'profile_image' => 'https://images.unsplash.com/photo-1595273670150-bd0c3c392e46?w=300',
+                'bio' => 'Traditional Egyptian home cooking with a modern presentation style.',
+                'type' => 'chef',
+                'email_verified_at' => now(),
+            ],
+        ];
+
+        foreach ($chefUsers as $userData) {
+            User::create($userData);
+        }
+    }
+}


### PR DESCRIPTION
- Created 8 seeders for all main entities:
  * UserSeeder: 8 chef users with realistic data
  * CategorySeeder: 17 food categories (breakfast, lunch, dinner)
  * IngredientSeeder: 93 ingredients (basic + fruits)
  * ChefSeeder: 8 chef profiles with detailed info
  * DishSeeder: 28 diverse dishes from different cuisines
  * DishSizeSeeder: 84 size variations (small, medium, large)
  * DishIngredientSeeder: 155+ dish-ingredient relationships
  * CouponSeeder: 21 discount coupons with various types

- Fixed foreign key constraints in migrations
- Updated Chef and Customer models with proper primary key configuration
- All data populated successfully with realistic pricing and relationships